### PR TITLE
Update lib/resty/http.lua

### DIFF
--- a/lib/resty/http.lua
+++ b/lib/resty/http.lua
@@ -358,6 +358,9 @@ function request(self, reqt)
         body, err = receivebody(sock, headers, nreqt)
         if err then
             sock:close()
+            if code == 200 then
+                return 1, code, headers, status, nil
+            end
             return nil, "read body failed " .. err
         end
     end


### PR DESCRIPTION
sometimes the server returns empty body, but the request is still valid (e.g. when calling webservices)

check if http response is 200 and then return ok with empty body
