### PR TITLE
the header content-length may equal to zero

### DIFF
--- a/lib/resty/http.lua
+++ b/lib/resty/http.lua
@@ -200,7 +200,7 @@ local function receivebody(sock, headers, nreqt)
                 end
             end
         end
-    elseif headers["content-length"] ~= nil and headers["content-length"] >= "0" then
+    elseif headers["content-length"] ~= nil and tonumber(headers["content-length"]) >= 0 then
         -- content length
         local length = tonumber(headers["content-length"])
         if length > nreqt.max_body_size then


### PR DESCRIPTION
In rfc2616 14.13 Content-Length:
`Any Content-Length greater than or equal to zero is a valid value.`
