### PR TITLE
http.lua solve the exception types

### DIFF
--- a/lib/resty/http.lua
+++ b/lib/resty/http.lua
@@ -139,7 +139,12 @@ local function receiveheaders(sock, headers)
             if err then return nil, err end
         end
         -- save pair in table
-        if headers[name] then headers[name] = headers[name] .. ", " .. value
+        if headers[name] then 
+	    if name == "set-cookie" then
+	        headers[name] = headers[name] .. "\r" .. value
+	    else
+	        headers[name] = headers[name] .. ", " .. value
+	    end
         else headers[name] = value end
     end
     return headers


### PR DESCRIPTION
Solve the exception types.
Not just cookies may be for the table type,but other types may produce errors.
