### PR TITLE
Fix an infinite loop in receivebody()

### DIFF
--- a/lib/resty/http.lua
+++ b/lib/resty/http.lua
@@ -198,7 +198,9 @@ local function receivebody(sock, headers, nreqt)
         while true do
             local chunk_header = sock:receiveuntil("\r\n")
             local data, err, partial = chunk_header()
-            if not err then
+            if not data then
+                return nil,err
+            else
                 if data == "0" then
                     return body -- end of chunk
                 else


### PR DESCRIPTION
Fixed https://github.com/liseen/lua-resty-http/issues/34.
Note that this fix checks chunk_header() return value `data`  instead of `err`  according to [official example of tcpsock:receiveuntil](https://github.com/openresty/lua-nginx-module#tcpsockreceiveuntil).

Also it does not check `partial`, `partial` data may be an incomplete chunk data if error occurs.