### PR TITLE
optimize body receving: use body chunk table instead of per body chunk concat

### DIFF
--- a/lib/resty/http.lua
+++ b/lib/resty/http.lua
@@ -184,12 +184,12 @@ end
 
 local function receivebody(sock, headers, nreqt)
     local t = headers["transfer-encoding"] -- shortcut
-    local body = ''
+    local body = {} -- data chunks of response body
     local callback = nreqt.body_callback
     if not callback then
         local function bc(data, chunked_header, ...)
             if chunked_header then return end
-            body = body .. data
+            body[#body+1] = data
         end
         callback = bc
     end
@@ -202,7 +202,7 @@ local function receivebody(sock, headers, nreqt)
                 return nil,err
             else
                 if data == "0" then
-                    return body -- end of chunk
+                    return table.concat(body) -- end of chunk
                 else
                     local length = tonumber(data, 16)
 
@@ -234,7 +234,7 @@ local function receivebody(sock, headers, nreqt)
             return nil,err
         end
     end
-    return body
+    return table.concat(body)
 end
 
 local function shouldredirect(reqt, code, headers)


### PR DESCRIPTION
1. This optimization reduces memory complexity from `O(n*n)` to `O(n)`, where n is `response-body-size / recv_chunk_size`.
2. Note that another [pintsized/lua-resty-http](https://github.com/pintsized/lua-resty-http) repo has used this optimization, see [here](https://github.com/pintsized/lua-resty-http/blob/master/lib/resty/http.lua#L469).