### PR TITLE
dont set default port for url.parse

### DIFF
--- a/lib/resty/http.lua
+++ b/lib/resty/http.lua
@@ -15,7 +15,6 @@ local USERAGENT = 'resty.http/' .. _VERSION
 -- default url parts
 local default = {
     host = "",
-    port = PORT,
     path ="/",
     scheme = "http"
 }


### PR DESCRIPTION
* Try to fixed #31.
* This patch is based on https://github.com/liseen/lua-resty-http/pull/32.
* For more details, see https://github.com/liseen/lua-resty-http/pull/32#issuecomment-310619936.